### PR TITLE
Add S3 options: httpOptions, maxRetries

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ For the `FS` persistor, the `bucketName` should be the full path to the folder o
 - `s3.key` (required): The AWS access key ID
 - `s3.secret` (required): The AWS secret access key
 - `s3.partSize`: The part size for S3 uploads. Defaults to 100 megabytes.
+- `s3.httpOptions`: HTTP options passed directly to the [S3 constructor](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property).
+- `s3.maxRetries`: The number of times the S3 client will retry in case of an error
 - `s3.endpoint`: For testing - overrides the S3 endpoint to use a different service (e.g. a fake S3 server)
 - `s3.pathStyle`: For testing - use old path-style URLs, for services that do not support subdomain-based access
 

--- a/src/S3Persistor.js
+++ b/src/S3Persistor.js
@@ -361,6 +361,12 @@ module.exports = class S3Persistor extends AbstractPersistor {
       options.s3ForcePathStyle = true
     }
 
+    for (const opt of ['httpOptions', 'maxRetries']) {
+      if (this.settings[opt]) {
+        options[opt] = this.settings[opt]
+      }
+    }
+
     return options
   }
 

--- a/test/unit/S3PersistorTests.js
+++ b/test/unit/S3PersistorTests.js
@@ -265,6 +265,21 @@ describe('S3PersistorTests', function () {
       })
     })
 
+    describe('when given S3 options', function () {
+      const httpOptions = { timeout: 2000 }
+      const maxRetries = 2
+
+      beforeEach(async function () {
+        settings.httpOptions = httpOptions
+        settings.maxRetries = maxRetries
+        await S3Persistor.getObjectStream(bucket, key)
+      })
+
+      it('configures the S3 client appropriately', function () {
+        expect(S3).to.have.been.calledWithMatch({ httpOptions, maxRetries })
+      })
+    })
+
     describe("when the file doesn't exist", function () {
       let error, stream
 


### PR DESCRIPTION
v1 history sets these options explicitly in production to avoid spending too much time fetching history. I don't know if we'll need them with GCS. I'm tempted to try with the default values.

I also added an option to prevent the s3 backend from using the DeleteObjects API, which fake-s3 doesn't support.