### PR TITLE
Add default parameter for 'opts' in MigrationPersistor.getObjectStream

### DIFF
--- a/src/MigrationPersistor.js
+++ b/src/MigrationPersistor.js
@@ -63,7 +63,7 @@ module.exports = class MigrationPersistor extends AbstractPersistor {
     return this._runOnBoth('deleteDirectory', ...args)
   }
 
-  async getObjectStream(bucket, key, opts) {
+  async getObjectStream(bucket, key, opts = {}) {
     const shouldCopy = this.settings.copyOnMiss && !opts.start && !opts.end
 
     try {


### PR DESCRIPTION
`opts` should be optional, so make sure that we don't crash if none are supplied to `getObjectStream` and `copyOnMiss` is enabled.