### PR TITLE
Disable auto-decompression in GCS persistor

### DIFF
--- a/src/GcsPersistor.js
+++ b/src/GcsPersistor.js
@@ -102,7 +102,7 @@ module.exports = class GcsPersistor extends AbstractPersistor {
     const stream = this.storage
       .bucket(bucketName)
       .file(key)
-      .createReadStream(opts)
+      .createReadStream({ decompress: false, ...opts })
 
     // ingress to us from gcs
     const observer = new PersistorHelper.ObserverStream({

--- a/test/unit/GcsPersistorTests.js
+++ b/test/unit/GcsPersistorTests.js
@@ -160,6 +160,12 @@ describe('GcsPersistorTests', function () {
         expect(GcsFile.createReadStream).to.have.been.called
       })
 
+      it('disables automatic decompression', function () {
+        expect(GcsFile.createReadStream).to.have.been.calledWith({
+          decompress: false
+        })
+      })
+
       it('pipes the stream through the meter', function () {
         expect(ReadStream.pipe).to.have.been.calledWith(
           sinon.match.instanceOf(Transform)
@@ -183,6 +189,7 @@ describe('GcsPersistorTests', function () {
 
       it('passes the byte range on to GCS', function () {
         expect(GcsFile.createReadStream).to.have.been.calledWith({
+          decompress: false,
           start: 5,
           end: 10
         })


### PR DESCRIPTION
The GCS library [automatically decompresses files with Content-encoding: gzip](https://googleapis.dev/nodejs/storage/latest/global.html#CreateReadStreamOptions). This is very useful, but the S3 library doesn't do that, so we need to disable the feature in GCS so that it behaves the same way other persistors behave.