### PR TITLE
Don't try to delete files if none are found in a directory

### DIFF
--- a/src/GcsPersistor.js
+++ b/src/GcsPersistor.js
@@ -220,9 +220,15 @@ module.exports = class GcsPersistor extends AbstractPersistor {
         .bucket(bucketName)
         .getFiles({ directory: key })
 
-      await asyncPool(this.settings.deleteConcurrency, files, async (file) => {
-        await this.deleteObject(bucketName, file.name)
-      })
+      if (Array.isArray(files) && files.length > 0) {
+        await asyncPool(
+          this.settings.deleteConcurrency,
+          files,
+          async (file) => {
+            await this.deleteObject(bucketName, file.name)
+          }
+        )
+      }
     } catch (err) {
       const error = PersistorHelper.wrapError(
         err,


### PR DESCRIPTION
`tiny-async-pool` has a debug assertion that the value passed is an array, and also requires that at least one item is present in the array. This can cause problems when trying to delete an empty directory.

This patch verifies that the array exists and has stuff in it, before trying to delete its contents.