### PR TITLE
Make 404 error handling on deletes more specific

### DIFF
--- a/src/GcsPersistor.js
+++ b/src/GcsPersistor.js
@@ -200,17 +200,21 @@ module.exports = class GcsPersistor extends AbstractPersistor {
       if (this.settings.unlockBeforeDelete) {
         await file.setMetadata({ eventBasedHold: false })
       }
-      await file.delete()
+      try {
+        await file.delete()
+      } catch (err) {
+        // ignore 404s: it's fine if the file doesn't exist.
+        if (err.code !== 404) {
+          throw err
+        }
+      }
     } catch (err) {
-      const error = PersistorHelper.wrapError(
+      throw PersistorHelper.wrapError(
         err,
         'error deleting GCS object',
         { bucketName, key },
         WriteError
       )
-      if (!(error instanceof NotFoundError)) {
-        throw error
-      }
     }
   }
 


### PR DESCRIPTION
The GCS persistor error handler ignores 404 errors on deletes. However, the net is too wide cast, and 404 errors coming from the dual-bucket lifecycle mechanism are also ignored.

I got caught by this when I forgot to remove the dual-bucket mechanism configuration in https://github.com/overleaf/google-ops/pull/1312

### Manual testing

* [x] Deploy v1 history in staging with the bad configuration and test that the chunk deletion task fails
* [x] Redeploy in staging with the good configuration and test that a non-existent old chunk gets ignored